### PR TITLE
Modern linux detection

### DIFF
--- a/ffpass/__init__.py
+++ b/ffpass/__init__.py
@@ -196,7 +196,8 @@ def addNewLogins(key, jsonLogins, logins):
 def guessDir():
     dirs = {
         'darwin': '~/Library/Application Support/Firefox',
-        'linux2': '~/.mozilla/firefox'
+        'linux2': '~/.mozilla/firefox',
+        'linux': '~/.mozilla/firefox'
     }
     if sys.platform in dirs:
         path = Path(dirs[sys.platform]).expanduser()


### PR DESCRIPTION
Linux core > 3.3 would be detected as `linux` in sys.platform