### PR TITLE
find the correct value from nssPrivate

### DIFF
--- a/ffpass/__init__.py
+++ b/ffpass/__init__.py
@@ -82,7 +82,9 @@ def getKey(directory: Path, masterPassword=""):
         print("password checked", file=sys.stderr)
     # decrypt 3des key to decrypt "logins.json" content
     c.execute("SELECT a11,a102 FROM nssPrivate;")
-    row = next(c)
+    for row in c:
+        if row[1] == MAGIC1:
+            break
     a11 = row[0]  # CKA_VALUE
     assert row[1] == MAGIC1  # CKA_ID
     decodedA11, _ = der_decode(a11)


### PR DESCRIPTION
In my key4.db, the table nssPrivate has some rows where a11 == NULL, thus the tool crashes. I add a check to find the correct row.