### PR TITLE
Updated install code from 'pip' to 'pip3'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ provide these features.
 ffpass requires Python 3.6+ and will work with Firefox 58+
 
 ``` bash
-pip install ffpass
+pip3 install ffpass
 ```
 
 ## Features


### PR DESCRIPTION
Changed install code from 'pip' to 'pip3' as it will not install with 'pip' and because code is for python3.6+